### PR TITLE
make gitignore ignore any IntelliJ idea files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 *.iml
 .gradle
 /local.properties
-/.idea/workspace.xml
-/.idea/libraries
-.DS_Store
+/.idea
+/.DS_Store
 /build
 /captures
 .externalNativeBuild


### PR DESCRIPTION
New versions of Android studio apparently create some more files in the .idea/ directory which should be ignored as well.