### PR TITLE
stop camera preview in background thread

### DIFF
--- a/barcodescanner/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeCapture.java
+++ b/barcodescanner/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeCapture.java
@@ -263,9 +263,14 @@ public final class BarcodeCapture extends BarcodeFragment {
     @Override
     public void onPause() {
         super.onPause();
-        if (mPreview != null) {
-            mPreview.stop();
-        }
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                if (mPreview != null) {
+                    mPreview.stop();
+                }
+            }
+        }).start();
     }
 
     /**


### PR DESCRIPTION
This is to reduce lag when navigating away from the barcode capture fragment.
Access to the camera in CameraSource is synchronized, so it should be thread safe.