### PR TITLE
RequestLayout after the camera source has been started

### DIFF
--- a/barcodescanner/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSourcePreview.java
+++ b/barcodescanner/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSourcePreview.java
@@ -90,6 +90,7 @@ public class CameraSourcePreview extends ViewGroup {
     private void startIfReady() throws IOException, SecurityException {
         if (mStartRequested && mSurfaceAvailable) {
             mCameraSource.start(mSurfaceView.getHolder());
+            requestLayout();
             if (mOverlay != null) {
                 Size size = mCameraSource.getPreviewSize();
                 int min = Math.min(size.getWidth(), size.getHeight());


### PR DESCRIPTION
RequestLayout after the camera source has been started to fix distorted camera preview image caused by "guessed" preview size.

(The camera preview in the sample app is distorted on my test device. This line of code fixes this)